### PR TITLE
fix using lxml and requests gets unicode error.

### DIFF
--- a/brownant/pipeline/network.py
+++ b/brownant/pipeline/network.py
@@ -120,7 +120,7 @@ class TextResponseProperty(ResponseProperty):
 
     def prepare(self):
         super(TextResponseProperty, self).prepare()
-        self.attr_names.setdefault("content_method", "text")
+        self.attr_names.setdefault("content_method", "content")
 
 
 class JSONResponseProperty(ResponseProperty):


### PR DESCRIPTION
when I use [The Declarative Demo](http://brownant.readthedocs.io/en/latest/userguide/quickstart.html#the-declarative-demo),I receive this error - `Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration`.

use `content` instead of `text`,  it can work:-)